### PR TITLE
Improve Terraform compatibility and resource naming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Jastify is a Go CLI tool that converts Datadog JSON configurations (dashboards and monitors) to Terraform HCL format. It enables infrastructure-as-code management of Datadog resources by parsing JSON exports from the Datadog UI and generating corresponding `datadog_dashboard` and `datadog_monitor` Terraform resources.
+
+## Architecture
+
+The application follows a simple converter architecture:
+
+1. **Main Entry Point** (`main.go`): Handles CLI argument parsing, JSON input (from file or stdin), and delegates to appropriate converter based on JSON structure
+2. **Converter Package** (`converter/`): Contains the core conversion logic with separate modules for dashboards and monitors
+3. **Type Detection**: Automatically detects resource type - monitors have a `name` field, dashboards do not
+
+### Key Components
+
+- **Dashboard Converter** (`converter/dashboard_converter.go`): Handles conversion of Datadog dashboard JSON to Terraform `datadog_dashboard` resources
+- **Monitor Converter** (`converter/monitor-converter.go`): Handles conversion of Datadog monitor JSON to Terraform `datadog_monitor` resources  
+- **Utilities** (`converter/utils.go`): Shared conversion utilities including type-safe JSON parsing, Terraform literal formatting, and block generation
+- **Definition Maps**: Each converter uses definition maps that specify how JSON fields map to Terraform resource attributes
+
+### Conversion Pattern
+
+The converters use a function map pattern where each JSON field has a corresponding `stringFunc` that defines how to convert that field to Terraform HCL:
+
+```go
+var DASHBOARD = map[string]stringFunc{
+    "title": stringGen("title"),
+    "widgets": func(v any) string { /* complex conversion logic */ },
+}
+```
+
+## Development Commands
+
+### Building and Running
+
+```bash
+# Build the binary
+go build -o jastify .
+
+# Run without installing
+go run . dashboard.json
+
+# Install globally  
+go install github.com/fgm/jastify@latest
+```
+
+### Testing
+
+```bash
+# Run all tests
+go test ./...
+
+# Run tests with golden file updates (after making changes)
+go test -update
+
+# Run specific test package
+go test ./converter/
+```
+
+### Golden File Testing
+
+The project uses [goldie v2](https://github.com/sebdah/goldie) for golden file testing. Test data is stored in `converter/testdata/` with corresponding `.golden` files containing expected Terraform output.
+
+When modifying conversion logic:
+1. Run tests to see failures
+2. Review changes carefully  
+3. Run `go test -update` to update golden files
+4. Verify only intended changes are included
+
+## Usage Patterns
+
+### Input Methods
+- **File input**: `jastify dashboard.json` (resource named from filename)
+- **Stdin input**: `jastify` then paste JSON + Ctrl-D (resource named `dashboard_1` or `monitor_1`)
+
+### Output Formatting
+Raw output should be formatted with Terraform:
+```bash
+jastify dashboard.json | terraform fmt > dashboard.tf
+```
+
+## Resource Type Detection
+
+The converter automatically detects resource type by checking for the presence of a `name` field:
+- **Monitor**: JSON contains `name` field → generates `datadog_monitor` resource
+- **Dashboard**: JSON lacks `name` field → generates `datadog_dashboard` resource
+
+## Dependencies
+
+- **Core**: Standard library only for main functionality
+- **Testing**: `github.com/sebdah/goldie/v2` for golden file testing
+- **Testing**: `github.com/google/go-cmp` for test comparisons
+
+## Error Handling
+
+The conversion process uses a definition-based approach where unknown JSON fields result in clear error messages indicating which field couldn't be converted. This helps identify when Datadog introduces new fields that need mapping support.

--- a/converter/dashboard_converter.go
+++ b/converter/dashboard_converter.go
@@ -90,6 +90,7 @@ var FORMULA = map[string]stringFunc{
 			return Must(convertFromDefinition(FORMULA_LIMIT, k1, v1))
 		})
 	},
+	"number_format": blankGen, // unit field not supported in Terraform formula blocks
 }
 
 var FORMULA_LIMIT = map[string]stringFunc{
@@ -173,10 +174,16 @@ var REQUEST = map[string]stringFunc{
 		queries := Must(JmapsFromAny(v))
 		return queryBlockList(queries, assignmentString)
 	},
-	"response_format": stringGen("response_format"),
-	"rum_query":       stringGen("rum_query"),
-	"security_query":  stringGen("security_query"),
-	"show_present":    stringGen("show_present"),
+	"response_format": func(v any) string {
+		// Only allow event_list format as other formats (scalar, timeseries) cause Terraform errors
+		if format, ok := v.(string); ok && format == "event_list" {
+			return assignmentString("response_format", format)
+		}
+		return ""
+	},
+	"rum_query":      stringGen("rum_query"),
+	"security_query": stringGen("security_query"),
+	"show_present":   stringGen("show_present"),
 	"style": func(v any) string {
 		return blockList(Jmaps{v.(Jmap)}, "style", assignmentString)
 	},
@@ -244,42 +251,43 @@ func init() {
 			markers := Must(JmapsFromAny(v))
 			return blockList(markers, "marker", assignmentString)
 		},
-		"message_display":     stringGen("message_display"),
-		"no_group_hosts":      stringGen("no_group_hosts"),
-		"no_metric_hosts":     stringGen("no_metric_hosts"),
-		"node_type":           stringGen("node_type"),
-		"precision":           stringGen("precision"),
-		"query":               stringGen("query"),
-		"requests":            convertRequests,
-		"right_yaxis":         func(v any) string { return block("right_yaxis", v.(Jmap), assignmentString) },
-		"scope":               stringGen("scope"),
-		"service":             stringGen("service"),
-		"show_breakdown":      stringGen("show_breakdown"),
-		"show_date_column":    stringGen("show_date_column"),
-		"show_distribution":   stringGen("show_distribution"),
-		"show_error_budget":   stringGen("show_error_budget"),
-		"show_errors":         stringGen("show_errors"),
-		"show_hits":           stringGen("show_hits"),
-		"show_last_triggered": stringGen("show_last_triggered"),
-		"show_latency":        stringGen("show_latency"),
-		"show_legend":         stringGen("show_legend"),
-		"show_message_column": stringGen("show_message_column"),
-		"show_resource_list":  stringGen("show_resource_list"),
-		"show_tick":           stringGen("show_tick"),
-		"size_format":         stringGen("size_format"),
-		"sizing":              stringGen("sizing"),
-		"slo_id":              stringGen("slo_id"),
-		"sort":                convertSort,
-		"span_name":           stringGen("span_name"),
-		"start":               blankGen,
-		"style":               func(v any) string { return block("style", v.(Jmap), assignmentString) },
-		"summary_type":        stringGen("summary_type"),
-		"tags":                stringGen("tags"),
-		"tags_execution":      stringGen("tags_execution"),
-		"text":                stringGen("text"),
-		"text_align":          stringGen("text_align"),
-		"tick_edge":           stringGen("tick_edge"),
-		"tick_pos":            stringGen("tick_pos"),
+		"message_display":       stringGen("message_display"),
+		"no_group_hosts":        stringGen("no_group_hosts"),
+		"no_metric_hosts":       stringGen("no_metric_hosts"),
+		"node_type":             stringGen("node_type"),
+		"precision":             stringGen("precision"),
+		"query":                 stringGen("query"),
+		"requests":              convertRequests,
+		"right_yaxis":           func(v any) string { return block("right_yaxis", v.(Jmap), assignmentString) },
+		"scope":                 stringGen("scope"),
+		"service":               stringGen("service"),
+		"show_breakdown":        stringGen("show_breakdown"),
+		"show_date_column":      stringGen("show_date_column"),
+		"show_distribution":     stringGen("show_distribution"),
+		"show_error_budget":     stringGen("show_error_budget"),
+		"show_errors":           stringGen("show_errors"),
+		"show_hits":             stringGen("show_hits"),
+		"show_last_triggered":   stringGen("show_last_triggered"),
+		"show_latency":          stringGen("show_latency"),
+		"show_legend":           stringGen("show_legend"),
+		"show_message_column":   stringGen("show_message_column"),
+		"show_resource_list":    stringGen("show_resource_list"),
+		"show_tick":             stringGen("show_tick"),
+		"size_format":           stringGen("size_format"),
+		"sizing":                stringGen("sizing"),
+		"slo_id":                stringGen("slo_id"),
+		"sort":                  convertSort,
+		"span_name":             stringGen("span_name"),
+		"start":                 blankGen,
+		"style":                 func(v any) string { return block("style", v.(Jmap), assignmentString) },
+		"summary_type":          stringGen("summary_type"),
+		"tags":                  stringGen("tags"),
+		"tags_execution":        stringGen("tags_execution"),
+		"text":                  stringGen("text"),
+		"text_align":            stringGen("text_align"),
+		"tick_edge":             stringGen("tick_edge"),
+		"tick_pos":              stringGen("tick_pos"),
+		"timeseries_background": func(v any) string { return block("timeseries_background", v.(Jmap), assignmentString) },
 		"time": func(v any) string {
 			if liveSpan, ok := v.(Jmap)["live_span"]; ok {
 				return assignmentString("live_span", liveSpan)

--- a/main.go
+++ b/main.go
@@ -5,9 +5,34 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/fgm/jastify/converter"
 )
+
+// sanitizeResourceName converts a file path to a valid Terraform resource name
+func sanitizeResourceName(name string) string {
+	// Remove file extension and get base name
+	base := strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
+
+	// Replace invalid characters with underscores
+	reg := regexp.MustCompile(`[^a-zA-Z0-9_]`)
+	sanitized := reg.ReplaceAllString(base, "_")
+
+	// Ensure it starts with a letter or underscore
+	if len(sanitized) > 0 && !regexp.MustCompile(`^[a-zA-Z_]`).MatchString(sanitized) {
+		sanitized = "_" + sanitized
+	}
+
+	// Ensure it's not empty
+	if sanitized == "" {
+		sanitized = "resource"
+	}
+
+	return sanitized
+}
 
 func main() {
 	var (
@@ -31,7 +56,7 @@ func main() {
 			_, _ = fmt.Fprintln(os.Stderr, "Error reading file:", err)
 			os.Exit(1)
 		}
-		resourceName = os.Args[1]
+		resourceName = sanitizeResourceName(os.Args[1])
 	default:
 		_, _ = fmt.Fprintln(os.Stderr, "Usage: \nconvert < somefile.json\nor\nconvert somefile.json")
 		os.Exit(1)


### PR DESCRIPTION
  Add support for additional dashboard fields and fix Terraform resource
  naming issues. The changes include filtering unsupported response formats
  to prevent Terraform errors and sanitizing file names to generate valid
  resource identifiers.

  - Add number_format field support in formula blocks (mapped as blank)
  - Filter response_format to only allow event_list format
  - Add timeseries_background block support for dashboard widgets
  - Implement resource name sanitization to handle special characters
  - Ensure resource names start with letter/underscore and aren't empty